### PR TITLE
Add theme mode settings

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -41,27 +41,26 @@ class MyApp extends StatelessWidget {
         ChangeNotifierProvider(create: (context) => Settings()),
         ChangeNotifierProvider(create: (context) => themeSettings)
       ],
-      builder: (context, widget) {
-        final themeSettings = context.watch<ThemeSettings>();
-
-        return MaterialApp(
-          title: 'Miniflutt',
-          theme: appTheme,
-          darkTheme: appThemeDark,
-          themeMode: themeSettings.themeMode,
-          initialRoute: '/',
-          routes: {
-            '/': (context) => MyHome(),
-            '/category': (context) => MyCategory(),
-            '/entry': (context) => MyEntry(),
-            '/feed': (context) => MyFeed(),
-            '/feed_create': (context) => MyFeedCreate(),
-            '/feeds': (context) => MyFeeds(),
-            '/search': (context) => MySearch(),
-            '/settings': (context) => MySettings(),
-          },
-        );
-      }
+      child: AnimatedBuilder(
+        animation: themeSettings,
+        builder: (context, child) => MaterialApp(
+            title: 'Miniflutt',
+            theme: appTheme,
+            darkTheme: appThemeDark,
+            themeMode: themeSettings.themeMode,
+            initialRoute: '/',
+            routes: {
+              '/': (context) => MyHome(),
+              '/category': (context) => MyCategory(),
+              '/entry': (context) => MyEntry(),
+              '/feed': (context) => MyFeed(),
+              '/feed_create': (context) => MyFeedCreate(),
+              '/feeds': (context) => MyFeeds(),
+              '/search': (context) => MySearch(),
+              '/settings': (context) => MySettings(),
+            },
+          ),
+      ),
     );
   }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -7,6 +7,7 @@ import 'models/data_all.dart';
 import 'models/entry_style.dart';
 import 'models/nav.dart';
 import 'models/settings.dart';
+import 'models/theme_settings.dart';
 import 'screens/home.dart';
 import 'screens/category.dart';
 import 'screens/entry.dart';
@@ -16,11 +17,19 @@ import 'screens/feeds.dart';
 import 'screens/search.dart';
 import 'screens/settings.dart';
 
-void main() {
-  runApp(MyApp());
+Future<void> main() async {
+  WidgetsFlutterBinding.ensureInitialized();
+
+  final themeSettings = await ThemeSettings.createAndLoad();
+
+  runApp(MyApp(themeSettings));
 }
 
 class MyApp extends StatelessWidget {
+  final ThemeSettings themeSettings;
+
+  const MyApp(this.themeSettings, { Key key }) : super(key: key);
+
   @override
   Widget build(BuildContext context) {
     return MultiProvider(
@@ -30,23 +39,29 @@ class MyApp extends StatelessWidget {
         ChangeNotifierProvider(create: (context) => EntryStyle()),
         ChangeNotifierProvider(create: (context) => Nav()),
         ChangeNotifierProvider(create: (context) => Settings()),
+        ChangeNotifierProvider(create: (context) => themeSettings)
       ],
-      child: MaterialApp(
-        title: 'Miniflutt',
-        theme: appTheme,
-        darkTheme: appThemeDark,
-        initialRoute: '/',
-        routes: {
-          '/': (context) => MyHome(),
-          '/category': (context) => MyCategory(),
-          '/entry': (context) => MyEntry(),
-          '/feed': (context) => MyFeed(),
-          '/feed_create': (context) => MyFeedCreate(),
-          '/feeds': (context) => MyFeeds(),
-          '/search': (context) => MySearch(),
-          '/settings': (context) => MySettings(),
-        },
-      ),
+      builder: (context, widget) {
+        final themeSettings = context.watch<ThemeSettings>();
+
+        return MaterialApp(
+          title: 'Miniflutt',
+          theme: appTheme,
+          darkTheme: appThemeDark,
+          themeMode: themeSettings.themeMode,
+          initialRoute: '/',
+          routes: {
+            '/': (context) => MyHome(),
+            '/category': (context) => MyCategory(),
+            '/entry': (context) => MyEntry(),
+            '/feed': (context) => MyFeed(),
+            '/feed_create': (context) => MyFeedCreate(),
+            '/feeds': (context) => MyFeeds(),
+            '/search': (context) => MySearch(),
+            '/settings': (context) => MySettings(),
+          },
+        );
+      }
     );
   }
 }

--- a/lib/models/theme_mode_item.dart
+++ b/lib/models/theme_mode_item.dart
@@ -1,0 +1,30 @@
+import 'dart:collection';
+
+import 'package:flutter/material.dart';
+
+class ThemeModeItem {
+  final String displayName;
+  final ThemeMode themeMode;
+
+  ThemeModeItem._(this.displayName, this.themeMode);
+
+  factory ThemeModeItem.of(final ThemeMode themeMode) {
+    return ThemeModeItem._(_displayName(themeMode), themeMode);
+  }
+}
+
+Set<ThemeModeItem> availableThemeModeItems() => LinkedHashSet.of(
+    ThemeMode.values.map((mode) => ThemeModeItem.of(mode)));
+
+String _displayName(final ThemeMode themeMode) {
+  switch (themeMode) {
+    case ThemeMode.system:
+      return "System Default";
+    case ThemeMode.light:
+      return "Light";
+    case ThemeMode.dark:
+      return "Dark";
+    default:
+      return themeMode.name;
+  }
+}

--- a/lib/models/theme_settings.dart
+++ b/lib/models/theme_settings.dart
@@ -32,6 +32,10 @@ class ThemeSettings extends ChangeNotifier {
   }
 
   void registerThemeModePreference(final ThemeMode themeMode) {
+    if(_themeMode == themeMode) {
+      return;
+    }
+
     _saveThemeModePreference(themeMode);
     _setThemeModePreference(themeMode);
   }

--- a/lib/models/theme_settings.dart
+++ b/lib/models/theme_settings.dart
@@ -1,0 +1,52 @@
+import 'package:flutter/material.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+ThemeMode _defaultMode() => ThemeMode.system;
+
+class ThemeSettings extends ChangeNotifier {
+  static const _THEME_MODE_KEY = 'themeModeId';
+
+  ThemeMode _themeMode;
+
+  ThemeMode get themeMode => _themeMode;
+
+  ThemeSettings._(this._themeMode);
+
+  static Future<ThemeSettings> createAndLoad() async {
+    final preferences = await SharedPreferences.getInstance();
+
+    final themeSettings =
+        ThemeSettings._(_loadThemeModePreference(preferences));
+
+    themeSettings.notifyListeners();
+
+    return themeSettings;
+  }
+
+  static ThemeMode _loadThemeModePreference(
+      final SharedPreferences preferences) {
+    final String themeModeId = preferences.getString(_THEME_MODE_KEY);
+
+    return ThemeMode.values.firstWhere((element) => element.name == themeModeId,
+        orElse: _defaultMode);
+  }
+
+  void registerThemeModePreference(final ThemeMode themeMode) {
+    _saveThemeModePreference(themeMode);
+    _setThemeModePreference(themeMode);
+  }
+
+  void _saveThemeModePreference(final ThemeMode themeMode) async {
+    _savePreference(_THEME_MODE_KEY, themeMode.name);
+  }
+
+  void _setThemeModePreference(final ThemeMode themeMode) {
+    this._themeMode = themeMode;
+    notifyListeners();
+  }
+
+  void _savePreference(final String key, final String value) async {
+    final sharedPreferences = await SharedPreferences.getInstance();
+    sharedPreferences.setString(key, value);
+  }
+}

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -9,11 +9,16 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:miniflutt/main.dart';
+import 'package:miniflutt/models/theme_settings.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 void main() {
   testWidgets('Counter increments smoke test', (WidgetTester tester) async {
+    SharedPreferences.setMockInitialValues({});
+    final themeSettings = await ThemeSettings.createAndLoad();
+
     // Build our app and trigger a frame.
-    await tester.pumpWidget(MyApp());
+    await tester.pumpWidget(MyApp(themeSettings));
 
     // Verify that our counter starts at 0.
     expect(find.text('0'), findsOneWidget);


### PR DESCRIPTION
Hi,

I would like to propose the following change that adds a setting to override the system theme mode, as also touched in #5.

While I am not affected by the issue directly, I would like to expand on this to add additional themes / theme-settings in the future.

I tried to adhere to the current conventions of the existing code and to not to change too much. However, the current settings are being loaded lazily. To avoid screen flickering, caused by mode switching from default to user preference, I had to eager load the relevant parts of the settings. This is also the reason why I kept the new settings separate from the existing model. A more advanced flutter engineer should double check the approach and I am happy to receive your feedback.

Best Regards,
Tobias

---

Unrelated: This app has allowed me to switch to Miniflux a while ago and is my daily driver when it comes to newsfeeds, so thank you for maintaining it!