### PR TITLE
Add "scale images" slider to render images with BoxFit.contain

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -27,7 +27,7 @@ class MyApp extends StatelessWidget {
       providers: [
         ChangeNotifierProvider(create: (context) => Data()),
         ChangeNotifierProvider(create: (context) => DataAll()),
-        ChangeNotifierProvider(create: (context) => EntryStyle()),
+        ChangeNotifierProvider(create: (context) => EntryStyle(), lazy: false),
         ChangeNotifierProvider(create: (context) => Nav()),
         ChangeNotifierProvider(create: (context) => Settings()),
       ],

--- a/lib/models/entry_style.dart
+++ b/lib/models/entry_style.dart
@@ -4,6 +4,7 @@ import 'package:shared_preferences/shared_preferences.dart';
 
 class EntryStyle extends ChangeNotifier {
   FontSize? fontSize;
+  bool scaleImages;
 
   // The constructor allows refreshing at startup
   EntryStyle() {
@@ -25,5 +26,7 @@ class EntryStyle extends ChangeNotifier {
     } else {
       fontSize = FontSize.medium;
     }
+
+    scaleImages = prefs.getBool("scaleImages") ?? false;
   }
 }

--- a/lib/models/settings.dart
+++ b/lib/models/settings.dart
@@ -31,6 +31,7 @@ class Settings extends ChangeNotifier {
     entrySwipeRight = (prefs.getString('entrySwipeRight') ?? 'no');
     feedOnLongPress = (prefs.getString('feedOnLongPress') ?? 'no');
     fontSize = (prefs.getString('fontSize') ?? 'medium');
+    scaleImages = (prefs.getBool('scaleImages') ?? false);
     isLoad = false;
     notifyListeners();
   }

--- a/lib/screens/entry.dart
+++ b/lib/screens/entry.dart
@@ -112,6 +112,17 @@ class MyEntryBody extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final entryStyle = Provider.of<EntryStyle>(context, listen: false);
+    Map<String, CustomRender> customRender = {};
+    if (entryStyle.scaleImages) {
+      customRender = {
+      "img": (RenderContext context, Widget child) {
+        final attrs = context.tree.element?.attributes;
+        if (attrs != null) {
+          return Image.network(attrs['src'], fit: BoxFit.contain);
+        }
+      },
+    };
+    }
     return GestureDetector(
       child: SingleChildScrollView(
         child: Column(
@@ -152,6 +163,11 @@ class MyEntryBody extends StatelessWidget {
                   launchURL(url);
                 }
               },
+              onImageTap: (url, renderContext, attributes, element) async {
+                // Suggest to download images
+                return _handleURL(url, context);
+              },
+              customRender: customRender,
             ),
           ],
         ),

--- a/lib/screens/settings.dart
+++ b/lib/screens/settings.dart
@@ -248,7 +248,7 @@ class MySettingsFormState extends State<MySettingsForm> {
                   final SharedPreferences prefs =
                       await SharedPreferences.getInstance();
                   prefs.setString('entrySwipeLeft', val);
-                  setState(() => settings.entrySwipeRight = val);
+                  setState(() => settings.entrySwipeLeft = val);
                 },
               ),
               DropdownButtonFormField(
@@ -295,6 +295,23 @@ class MySettingsFormState extends State<MySettingsForm> {
                   setState(() => settings.fontSize = val);
                 },
               ),
+              Row(children: <Widget>[
+                Expanded(
+                    child: Text('Scale images to screen',
+                        textAlign: TextAlign.left)),
+                Switch(
+                  value: settings.scaleImages,
+                  onChanged: (val) async {
+                    final SharedPreferences prefs =
+                        await SharedPreferences.getInstance();
+                    prefs.setBool("scaleImages", val);
+                    final entryStyle =
+                        Provider.of<EntryStyle>(context, listen: false);
+                    await entryStyle.refresh();
+                    setState(() => settings.scaleImages = val);
+                  },
+                ),
+              ]),
               ListTile(
                 title: Text(
                   'Categories and feeds',


### PR DESCRIPTION
I've never worked with Dart or Flutter: there may be a better way to do this (ex: it'd be neat to fill the screen, not just the `td` containing the image).

![image](https://user-images.githubusercontent.com/8885466/202823864-6840e413-1204-484c-b4ce-4a88e26870d6.png)

Before:
![tempsnip](https://user-images.githubusercontent.com/8885466/202823971-63383cde-5d71-43ad-bb25-a81f2c226458.png)

After:
![tempsnip](https://user-images.githubusercontent.com/8885466/202824103-2d26c83c-083d-4f7b-b363-9a36835f1656.png)

Fixed a bug with swipeLeft while I was in there.

Cheers!
