### PR TITLE
feat: added reading time

### DIFF
--- a/lib/models/entry.dart
+++ b/lib/models/entry.dart
@@ -8,6 +8,7 @@ class Entry {
   final int? feedId;
   final String? hash;
   final int? id;
+  final int? readingTime;
   final String? publishedAt;
   final String? shareCode;
   bool? starred;
@@ -25,6 +26,7 @@ class Entry {
     this.hash,
     this.id,
     this.publishedAt,
+    this.readingTime,
     this.shareCode,
     this.starred,
     this.status,
@@ -43,6 +45,7 @@ class Entry {
       hash: json['hash'],
       id: json['id'],
       publishedAt: json['published_at'],
+      readingTime: json['reading_time'],
       shareCode: json['share_code'],
       starred: json['starred'],
       status: json['status'],

--- a/lib/screens/entry.dart
+++ b/lib/screens/entry.dart
@@ -59,6 +59,14 @@ class MyEntryHeader extends StatelessWidget {
                 .format(DateTime.parse(entry.publishedAt!)),
             textScaler: TextScaler.linear(0.75),
           ),
+          Text(
+            entry.readingTime!.toString() + " min read",
+            textScaler: TextScaler.linear(0.75),
+            style: TextStyle(
+              color: Theme.of(context).textTheme.titleSmall!.color,
+              fontWeight: FontWeight.bold,
+            )
+          )
         ],
       ),
     );

--- a/lib/screens/home.dart
+++ b/lib/screens/home.dart
@@ -216,19 +216,29 @@ class MyHomeEntryList extends StatelessWidget {
                 ),
               ),
               subtitle: Row(children: <Widget>[
-                Text((nav.currentFeedId == null
-                        ? entry.feed!.title! + '\n'
-                        : '') +
-                    DateFormat('yyy-MM-dd HH:mm')
-                        .format(DateTime.parse(entry.publishedAt!))),
-                Spacer(),
-                entry.starred!
-                    ? Icon(
-                        Icons.star,
-                        color: Colors.amber,
-                      )
-                    : Text(''),
-              ]),
+                Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: <Widget>[
+                    if (nav.currentFeedId == null) Text(entry.feed!.title!),
+                    Row(children: <Widget>[
+                      Text(
+                          DateFormat('yyy-MM-dd HH:mm')
+                              .format(DateTime.parse(entry.publishedAt!))
+                          
+                      ),
+                      Text(
+                        ' :: ${entry.readingTime} min read',
+                        style: TextStyle(
+                          color: Theme.of(context).disabledColor,
+                          fontStyle: FontStyle.italic,
+                        ),
+                      ),
+                    ]),
+                  ]),
+                  if (entry.starred!) Spacer(),
+                  if (entry.starred!) Icon(Icons.star, color: Colors.amber),
+                ],
+              ),
               onTap: () {
                 Navigator.pushNamed(
                   context,


### PR DESCRIPTION
added a field in the `Entry` model to hold reading time, and save it as we receive it via API. added reading time display directly in feed list and also in entry header

this solves #28 

i tried to be consistent with both interface and code styles, but feel free to make any change to better respect this project appearance!

![reading time in entry view](https://cdn.alemi.dev/tmp/miniflutt-reading-time-entry.png)
![reading time in feed view](https://cdn.alemi.dev/tmp/miniflutt-reading-time-feed.png)