### PR TITLE
feat: download content

### DIFF
--- a/lib/api/miniflux.dart
+++ b/lib/api/miniflux.dart
@@ -183,3 +183,15 @@ Future<bool> connectCheck() async {
     return false;
   }
 }
+
+Future<String> getEntryOriginalContent(int? entryId) async {
+  Map<String, dynamic> content = json.decode(
+    await _get('/v1/entries/$entryId/fetch-content', <String, String>{})
+  );
+  String new_content = content['content'];
+    Map<String, dynamic> params = {
+      "content": new_content,
+    };
+  await _put('/v1/entries/$entryId', params);
+  return new_content;
+}

--- a/lib/models/entry.dart
+++ b/lib/models/entry.dart
@@ -3,7 +3,7 @@ import 'feed.dart';
 class Entry {
   final String? author;
   final String? commentsUrl;
-  final String? content;
+  String? content;
   final Feed? feed;
   final int? feedId;
   final String? hash;

--- a/lib/screens/entry.dart
+++ b/lib/screens/entry.dart
@@ -15,6 +15,7 @@ import '../models/data.dart';
 import '../models/entry.dart';
 import '../models/entry_style.dart';
 import '../models/nav.dart';
+import '../api/miniflux.dart';
 import 'home.dart';
 
 class MyEntryHeader extends StatelessWidget {
@@ -160,8 +161,9 @@ class MyEntryBody extends StatelessWidget {
 }
 
 class MyEntryBottom extends StatelessWidget {
-  MyEntryBottom({Key? key, required this.entry}) : super(key: key);
+  MyEntryBottom({Key? key, required this.entry, required this.content_update}) : super(key: key);
   final Entry entry;
+  final Function(String) content_update;
 
   @override
   Widget build(BuildContext context) {
@@ -211,6 +213,13 @@ class MyEntryBottom extends StatelessWidget {
               );
             },
           ),
+          IconButton(
+            icon: Icon(Icons.download),
+            onPressed: () {
+              getEntryOriginalContent(entry.id)
+                .then((res) => this.content_update(res));
+            },
+          ),
           if (entry.commentsUrl != null && entry.commentsUrl != "")
             Consumer<Data>(
               builder: (context, data, child) {
@@ -227,7 +236,17 @@ class MyEntryBottom extends StatelessWidget {
   }
 }
 
-class MyEntry extends StatelessWidget {
+class MyEntry extends StatefulWidget {
+  MyEntry({Key? key}) : super(key: key);
+
+  MyEntryState createState() {
+    return MyEntryState();
+  }
+}
+
+class MyEntryState extends State<MyEntry> {
+  MyEntryState({Key? key});
+
   @override
   Widget build(BuildContext context) {
     final Entry? entry = ModalRoute.of(context)!.settings.arguments as Entry?;
@@ -241,6 +260,9 @@ class MyEntry extends StatelessWidget {
       controller: controller,
       itemBuilder: (context, index) {
         final entry = entries[index]!;
+        Function(String) updater = (txt) {
+          setState(() => entry.content = txt);
+        };
         return Scaffold(
           appBar: AppBar(
             title: Text(
@@ -248,7 +270,7 @@ class MyEntry extends StatelessWidget {
             ),
           ),
           body: MyEntryBody(entry: entry),
-          bottomNavigationBar: MyEntryBottom(entry: entry),
+          bottomNavigationBar: MyEntryBottom(entry: entry, content_update: updater),
           floatingActionButton: FloatingActionButton(
             child: Icon(Icons.open_in_browser),
             onPressed: () => launchURL(entry.url!),

--- a/lib/screens/entry.dart
+++ b/lib/screens/entry.dart
@@ -190,6 +190,19 @@ class MyEntryBottom extends StatelessWidget {
               );
             },
           ),
+          IconButton(
+            icon: Icon(Icons.download),
+            onPressed: () => getEntryOriginalContent(entry.id)
+              .then((res) {
+                this.content_update(res);
+                ScaffoldMessenger.of(context)
+                  .showSnackBar(SnackBar(content: Text('Downloaded!')));
+              })
+              .catchError((e) {
+                ScaffoldMessenger.of(context)
+                  .showSnackBar(SnackBar(content: Text('An error occured!\n$e')));
+              }),
+          ),
           Consumer<Data>(
             builder: (context, data, child) {
               return IconButton(
@@ -211,13 +224,6 @@ class MyEntryBottom extends StatelessWidget {
                     : Icons.visibility_off),
                 onPressed: () => data.toggleRead(entry.id),
               );
-            },
-          ),
-          IconButton(
-            icon: Icon(Icons.download),
-            onPressed: () {
-              getEntryOriginalContent(entry.id)
-                .then((res) => this.content_update(res));
             },
           ),
           if (entry.commentsUrl != null && entry.commentsUrl != "")


### PR DESCRIPTION
this PR adds a button to download+update article content, mimicking miniflux's frontend "download" button. since there is no API to directly do the whole thing, we first make miniflux fetch the original content with `/v1/entries/${id}/fetch-content`, once we receive that we PUT an entry update with the new content, and replace our local content String.


![download content button](https://cdn.alemi.dev/tmp/miniflutt-download-original-content.png)